### PR TITLE
S3バケットにアップロードされた画像を別のS3バケットに移動する実装を追加

### DIFF
--- a/cmd/lambda/converttowebp/main.go
+++ b/cmd/lambda/converttowebp/main.go
@@ -45,7 +45,7 @@ func createSession(region string) (*session.Session, error) {
 	return sess, nil
 }
 
-func s3Download(downloader *s3manager.Downloader, bucket string, key string) (f *os.File, err error) {
+func downloadFromS3(downloader *s3manager.Downloader, bucket string, key string) (f *os.File, err error) {
 	tmpFile, _ := os.CreateTemp("/tmp", "tmp_img_")
 
 	defer func() {
@@ -71,7 +71,7 @@ func s3Download(downloader *s3manager.Downloader, bucket string, key string) (f 
 	return tmpFile, err
 }
 
-func s3Upload(uploader *s3manager.Uploader, file *os.File, bucket string, key string) error {
+func uploadToS3(uploader *s3manager.Uploader, file *os.File, bucket string, key string) error {
 	_, err := uploader.Upload(&s3manager.UploadInput{
 		Bucket:      aws.String(bucket),
 		Body:        file,
@@ -92,7 +92,7 @@ func Handler(ctx context.Context, event events.S3Event) error {
 		bucket := record.S3.Bucket.Name
 		key := record.S3.Object.Key
 
-		file, err := s3Download(downloader, bucket, key)
+		file, err := downloadFromS3(downloader, bucket, key)
 		if err != nil {
 			return err
 		}
@@ -104,7 +104,7 @@ func Handler(ctx context.Context, event events.S3Event) error {
 
 		uploadKey := "encoded/" + uniqueId.String() + ".png"
 
-		err = s3Upload(uploader, file, os.Getenv("DESTINATION_BUCKET_NAME"), uploadKey)
+		err = uploadToS3(uploader, file, os.Getenv("DESTINATION_BUCKET_NAME"), uploadKey)
 		if err != nil {
 			return err
 		}

--- a/cmd/lambda/converttowebp/main.go
+++ b/cmd/lambda/converttowebp/main.go
@@ -2,29 +2,89 @@ package main
 
 import (
 	"context"
+	"io/ioutil"
 	"log"
+	"os"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"github.com/google/uuid"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/s3"
 )
 
-var svc *s3.S3
+var downloader *s3manager.Downloader
+var uploader *s3manager.Uploader
 
 //nolint:gochecknoinits
 func init() {
-	sess, err := session.NewSession()
+	region := os.Getenv("REGION")
+
+	sess, err := createSession(region)
 	if err != nil {
 		// TODO ここでエラーが発生した場合、致命的な問題が起きているのでちゃんとしたログを出すように改修する
 		log.Fatalln(err)
 	}
 
-	svc = s3.New(sess)
+	downloader = s3manager.NewDownloader(sess)
+	uploader = s3manager.NewUploader(sess)
+}
 
-	log.Println("⊂ﾟＵ┬───┬~")
-	log.Println(svc)
-	log.Println("⊂ﾟＵ┬───┬~")
+func createSession(region string) (*session.Session, error) {
+	sess, err := session.NewSession(&aws.Config{
+		S3ForcePathStyle: aws.Bool(true),
+		Region:           aws.String(region),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return sess, nil
+}
+
+func s3Download(downloader *s3manager.Downloader, bucket string, key string) (f *os.File, err error) {
+	tmpFile, _ := ioutil.TempFile("/tmp", "srctmp_")
+
+	defer func() {
+		err := os.Remove(tmpFile.Name())
+		if err != nil {
+			// TODO ここでエラーが発生した場合、致命的な問題が起きているのでちゃんとしたログを出すように改修する
+			log.Fatalln(err)
+		}
+	}()
+
+	_, err = downloader.Download(
+		tmpFile,
+		&s3.GetObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(key),
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tmpFile, err
+}
+
+func s3Upload(uploader *s3manager.Uploader, file *os.File, bucket string, key string) error {
+	_, err := uploader.Upload(&s3manager.UploadInput{
+		Bucket:      aws.String(bucket),
+		Body:        file,
+		ContentType: aws.String("image/png"),
+		Key:         aws.String(key),
+	})
+
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func Handler(ctx context.Context, event events.S3Event) error {
@@ -33,11 +93,22 @@ func Handler(ctx context.Context, event events.S3Event) error {
 		bucket := record.S3.Bucket.Name
 		key := record.S3.Object.Key
 
-		log.Println("🐱")
-		log.Println(ctx)
-		log.Println(bucket)
-		log.Println(key)
-		log.Println("🐱")
+		file, err := s3Download(downloader, bucket, key)
+		if err != nil {
+			return err
+		}
+
+		uniqueId, err := uuid.NewRandom()
+		if err != nil {
+			return err
+		}
+
+		uploadKey := "encoded/" + uniqueId.String() + ".png"
+
+		err = s3Upload(uploader, file, os.Getenv("DESTINATION_BUCKET_NAME"), uploadKey)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/cmd/lambda/converttowebp/main.go
+++ b/cmd/lambda/converttowebp/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -47,7 +46,7 @@ func createSession(region string) (*session.Session, error) {
 }
 
 func s3Download(downloader *s3manager.Downloader, bucket string, key string) (f *os.File, err error) {
-	tmpFile, _ := ioutil.TempFile("/tmp", "srctmp_")
+	tmpFile, _ := os.CreateTemp("/tmp", "tmp_img_")
 
 	defer func() {
 		err := os.Remove(tmpFile.Name())

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.16
 require (
 	github.com/aws/aws-lambda-go v1.23.0
 	github.com/aws/aws-sdk-go v1.37.30
+	github.com/google/uuid v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
+github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=

--- a/serverless.yml
+++ b/serverless.yml
@@ -20,6 +20,7 @@ provider:
   environment:
     DEPLOY_STAGE: ${env:DEPLOY_STAGE}
     TRIGGER_BUCKET_NAME: ${env:TRIGGER_BUCKET_NAME}
+    DESTINATION_BUCKET_NAME: ${env:DESTINATION_BUCKET_NAME}
 
 custom:
   defaultStage: dev
@@ -44,5 +45,5 @@ functions:
           event: s3:ObjectCreated:*
           rules:
             - prefix: uploads/
-            - suffix: .jpg
+            - suffix: .png
           existing: true


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/convert-webp-lambda/issues/2

# やった事

`TRIGGER_BUCKET_NAME` で指定したS3バケットにアップロードされたファイルを `DESTINATION_BUCKET_NAME` に移動させるLambda関数を実装。

なお将来的に利用しようと思っている用途が `png` から `webp` への変換なので `png` 画像がアップロードされたタイミングでのみ関数が動くようにしてある。